### PR TITLE
[refactor-detail]: 장바구니에 담는데이터타입 변경

### DIFF
--- a/services/detail/src/api/ShoppingBag.ts
+++ b/services/detail/src/api/ShoppingBag.ts
@@ -10,7 +10,6 @@ export const getShoppingBagAPI = async () => {
 
 export const putInShoppingBagAPI = async (data: string) => {
   try {
-    //data 형태 JSON.parse 로 변형한 타입으로 해야함 string 아님
     const res = await axios.post(`${BASE_URL}/shoppingBag`, data, {
       headers: {
         "Content-Type": "application/json",

--- a/services/detail/src/page/detail/selectItem/SelectItem.tsx
+++ b/services/detail/src/page/detail/selectItem/SelectItem.tsx
@@ -114,8 +114,9 @@ const ItemSelection: React.FC<{ data: dataRequire }> = ({ data }) => {
       } else {
         /* 중복아닐때 */
         /* 장바구니에 넣을때 필요한 데이터 추가 */
+        const option = { ...selectedOptions };
         const newItem = {
-          ...selectedOptions,
+          option,
           count: 1,
           id: data.id,
           imgSrc: data.imgSrc,
@@ -211,14 +212,12 @@ const ItemSelection: React.FC<{ data: dataRequire }> = ({ data }) => {
             onChange={(e) => handleOptionChange(option.label, e)}
           >
             {index !== 0 &&
-            selectedOptions[data.options[index - 1].label] === undefined 
-            ? (
+            selectedOptions[data.options[index - 1].label] === undefined ? (
               /* 앞선 옵션이 선택되지않았을 때 */
               <option value="">{`${
                 data.options[index - 1].label
               }을 선택해주세요`}</option>
-            ) 
-            : (
+            ) : (
               /* 앞선 옵션이 선택되어있을 때 */
               <>
                 <option value="">Select {option.label}</option>
@@ -238,10 +237,20 @@ const ItemSelection: React.FC<{ data: dataRequire }> = ({ data }) => {
       {
         <div className="items">
           {selectedItems.map((item, index) => {
+            /* 저장아이템 옵션출력 */
+            const optionKeys = item.option ? Object.keys(item.option) : [];
+            console.log(item.option["size"]);
             return (
               <div className="item" key={index}>
-                <span>{item.color}</span>
-                <span>{item.size}</span>
+                {optionKeys.map((optionkey, index) => {
+                  return (
+                    <span
+                      key={index}
+                    >{` ${optionkey}: ${item.option[optionkey]}`}</span>
+                  );
+                })}
+
+                {/* 수량 변경 버튼 */}
                 <div>
                   <button
                     onClick={() =>
@@ -306,7 +315,7 @@ const SelectSection = styled.section`
     border-bottom: 1px solid grey;
     height: 3rem;
     align-items: center;
-    font-size: 0.9rem;
+    font-size: 1rem;
   }
   select {
     width: 100%;


### PR DESCRIPTION
page/detail/selectItem: 장바구니에 담는 데이터를 json으로 변형하기전 데이터인 newItem에서 옵션들을 하나의 객체로 전달

변경 전 :
        const newItem = {
          ...selectedOptions,
          count: 1,
          id: data.id,
          imgSrc: data.imgSrc,
          name: data.name,
          deliveryFee: data.deliveryFee,
          price: data.price,
          noDeliveryPrice: data.noDeliveryPrice,
          orderPrice: data.price,
        };

변경 후:
        const option= {...selectedOptions};
        const newItem = {
          selectedOptions,
          count: 1,
          id: data.id,
          imgSrc: data.imgSrc,
          name: data.name,
          deliveryFee: data.deliveryFee,
          price: data.price,
          noDeliveryPrice: data.noDeliveryPrice,
          orderPrice: data.price,
        };