### PR TITLE
아이폰에서 캐러셸이동 문제 해결

### DIFF
--- a/services/home/src/components/carousel/elements/card/MainCarouselCard.tsx
+++ b/services/home/src/components/carousel/elements/card/MainCarouselCard.tsx
@@ -28,6 +28,8 @@ const CardArticle = styled.article<{ ratio: string }>`
   background-color: #d9d9d9;
   position: relative;
   background-color: red;
+  height:100%;
+  aspect-ratio: ${(props) => props.ratio}; // 이게 카드 비율 결정
 
   .detail {
     position: absolute;
@@ -38,7 +40,6 @@ const CardArticle = styled.article<{ ratio: string }>`
     font-size: 2rem;
   }
 
-  aspect-ratio: ${(props) => props.ratio}; // 이게 카드 비율 결정
   img {
     width: 100%;
     object-fit: cover;

--- a/services/home/src/components/carousel/elements/card/SmallCarouselCard.tsx
+++ b/services/home/src/components/carousel/elements/card/SmallCarouselCard.tsx
@@ -38,9 +38,11 @@ const Card = styled.div<{ ratio: string }>`
   flex-direction: column;
   justify-content: center;
 
+  height:100%;
   aspect-ratio: ${(props) => props.ratio};
   flex-shrink: 0;
   box-shadow: 10px 5px 5px #2c2e2d11;
+  padding-left:1rem;
 
   img {
     width: 100%;

--- a/services/home/src/components/carousel/smallCrousel/index.tsx
+++ b/services/home/src/components/carousel/smallCrousel/index.tsx
@@ -22,7 +22,6 @@ const SmallCarousel: React.FC<{ adata: Item[] }> = ({ adata }) => {
       width={"100%"}
       layerRatio={"2/1"}
       cardRatio={"1/2"}
-      gap={"1rem"}
       maxHeight={"400px"}
     />
   );


### PR DESCRIPTION
아이폰에서 부모도 width가 값이고 자식도 width:% 값일때 aspect-ratio에서 에러로 추정 
height값을 100%로 주어 해결  