### PR TITLE
[fix-detail]: 캐싱 키값 설정에러, 반복문 내 상태변화

### DIFF
--- a/services/detail/src/api/CacheAxios.ts
+++ b/services/detail/src/api/CacheAxios.ts
@@ -33,7 +33,7 @@ CacheAxios.interceptors.request.use(
 
     // 타임스탬프를 세션에서 가져옴
     const lastModifiedTimestamp = getSessionStorage(
-      `${id}_${type}_lastModifiedTimestamp`
+      `${id}_${type}_${page}_lastModifiedTimestamp`
     );
 
     // 타임스템프가 있을때만 데이터가 최신인지 비교하기위한
@@ -70,7 +70,7 @@ CacheAxios.interceptors.response.use(
     // Last-Modified 헤더 세션 스토리지 업데이트
     if (serverLastModified) {
       addSessionStorage(
-        `${id}_${type}_lastModifiedTimestamp`,
+        `${id}_${type}_${page}_lastModifiedTimestamp`,
         serverLastModified
       );
     }

--- a/services/detail/src/components/pagenation/card/AskCard.tsx
+++ b/services/detail/src/components/pagenation/card/AskCard.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
+import { useContext } from "react";
+import { PageNationContext } from "../../../../../../shared/shared/lib/MyPageNation";
 
 interface itemRequire {
   owner: string;
@@ -15,19 +17,8 @@ interface AskCardProps {
 }
 
 const AskCard: React.FC<AskCardProps> = ({ index, item }) => {
-  const [isHide, setIsHide] = useState(true);
-
-  /* 비밀번호 입력값을 통해 현재카드의 상태 변경 함수
-    현재카드의 비밀번호와 입력값이 같으면 상태를 true로 변경
-  */
-  const inputPassword = (
-    e: React.ChangeEvent<HTMLInputElement>,
-    password: string
-  ) => {
-    if (e.target.value === password) {
-      setIsHide(false);
-    }
-  };
+  /* 반복문안에서 상태를 관리하기위한 컨텍스트 */
+  const context = useContext(PageNationContext); 
 
   return (
     <AskCardArticle className="review">
@@ -43,12 +34,12 @@ const AskCard: React.FC<AskCardProps> = ({ index, item }) => {
       </div>
 
       <div>
-        {isHide ? (
+        {context?.cardState[index] ? (
           <div className="Password">
             비밀번호 :
             <input
               type="text"
-              onChange={(e) => inputPassword(e, item.password)}
+              onChange={(e) => context.func(e, item.password, index)}
             />
           </div>
         ) : (

--- a/services/detail/src/components/pagenation/card/ReviewCard.tsx
+++ b/services/detail/src/components/pagenation/card/ReviewCard.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
+import { useContext } from "react";
+import { PageNationContext } from "../../../../../../shared/shared/lib/MyPageNation";
 
 interface itemRequire {
   user: string;
@@ -15,23 +17,15 @@ interface ReviewCardProps {
   item: itemRequire;
 }
 
-
 const ReviewCard: React.FC<ReviewCardProps> = ({ index, item }) => {
-  const [ isClicked, setIsClicked ] = useState(false);
-
-  /* 클릭시 카드의 전체 내용이 보이게 하는 함수 
-      현재 상태의 index가 현재 카드의 index와 같은경우 undefinded로 변경
-      다른경우 현재 카드 index로 설정 
-  */
-  const showAll = () => {
-    setIsClicked(!isClicked);
-  };
+  /* 반복문안에서 상태를 관리하기위한 컨텍스트 */
+  const context = useContext(PageNationContext);
 
   return (
     <ReviewCardArticle
       key={index}
-      onClick={() => showAll()}
-      state={isClicked} // 현재 카드가 클릭된 카드인지확인
+      onClick={() => context?.func(index)}
+      state={context?.cardState[index] ?? false} // 현재 카드가 클릭된 카드인지확인
     >
       <div className="header">
         <div>
@@ -62,8 +56,8 @@ const ReviewCardArticle = styled.div<{ state: boolean }>`
   border-bottom: 1px solid black;
   padding: 10px 0;
 
-  height:${(props) => (props.state ? "" : "10rem")};
-  
+  height: ${(props) => (props.state ? "" : "10rem")};
+
   cursor: pointer;
   span {
     word-break: break-all;

--- a/services/detail/src/page/detail/askPageNation/AskPageNation.tsx
+++ b/services/detail/src/page/detail/askPageNation/AskPageNation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PagenationHeader from "../../../components/pagenation/header/PagenationHeader";
 import { getAsk } from "../../../api/Detail";
 import AskCard from "../../../components/pagenation/card/AskCard";
@@ -8,6 +8,7 @@ import { PageNumNavComponent } from "../../../../../../shared/shared/lib/MyPageN
 import { usePagination } from "../../../../../../shared/shared/hooks/usePageNation";
 import styled from "styled-components";
 import NonItemCard from "../../../components/pagenation/card/NonItemCard";
+import { PageNationContextProvider } from "../../../../../../shared/shared/lib/MyPageNation";
 
 /* 문의 요청결과 데이터 타입 */
 interface AskRequire {
@@ -31,18 +32,50 @@ const AskPageNation: React.FC<{ productID: string }> = ({ productID }) => {
     productID,
     numOfShow
   );
-  console.log(paginationResult.showData);
+
+  /* 비밀글 상태 */
+  const [isHide, setIsHide] = useState<Record<number, any>>({});
+
+  /* 비밀글 초기값 설정 */
+  useEffect(() => {
+    setIsHide(() => {
+      const initialState: Record<number, any> = {};
+      for (let i = 0; i <= paginationResult.showData.length; i++) {
+        initialState[i] = true;
+      }
+      return initialState;
+    });
+  }, [paginationResult.showData]);
+
+  /* 비밀번호 입력값을 통해 현재카드의 상태 변경 함수
+    현재카드의 비밀번호와 입력값이 같으면 상태를 true로 변경
+  */
+  const inputPassword = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    password: string,
+    index: number
+  ) => {
+    if (e.target.value === password) {
+      setIsHide((prevIsHide) => ({
+        ...prevIsHide,
+        [index]: false,
+      }));
+    }
+  };
 
   return (
     /* 페이지네이션 Outlayer 레이아웃 */
     <PagenationHeader title={"문의"}>
       {paginationResult.showData.length ? (
         <>
-          {/* 페이지네이션 반복되는 카드 구역 */}
-          <ShowDataComponent
-            showData={paginationResult.showData}
-            renderCard={AskCard}
-          />
+          {/* 상태 변경을 처리하기위한 컨텍스트 */}
+          <PageNationContextProvider cardState={isHide} func={inputPassword}>
+            {/* 페이지네이션 반복되는 카드 구역 */}
+            <ShowDataComponent
+              showData={paginationResult.showData}
+              renderCard={AskCard}
+            />
+          </PageNationContextProvider>
 
           {/* 페이지네이션 숫자 네비게이터 구역 */}
           <PageNumNavComponent

--- a/services/detail/src/page/detail/reviewPageNation/ReviewPageNation.tsx
+++ b/services/detail/src/page/detail/reviewPageNation/ReviewPageNation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PagenationHeader from "../../../components/pagenation/header/PagenationHeader";
 import { getReview } from "../../../api/Detail";
 import ReviewCard from "../../../components/pagenation/card/ReviewCard";
@@ -7,6 +7,7 @@ import { usePagination } from "../../../../../../shared/shared/hooks/usePageNati
 import { ShowDataComponent } from "../../../../../../shared/shared/lib/MyPageNation";
 import { PageNumNavComponent } from "../../../../../../shared/shared/lib/MyPageNation";
 import NonItemCard from "../../../components/pagenation/card/NonItemCard";
+import { PageNationContextProvider } from "../../../../../../shared/shared/lib/MyPageNation";
 
 /* 리뷰 요청결과 데이터 타입 */
 interface reviewRequire {
@@ -32,16 +33,40 @@ const ReviewPageNation: React.FC<{ productID: string }> = ({ productID }) => {
     numOfShow
   );
 
+  const [isClicked, setIsClicked] = useState<Record<number, any>>({});
+
+  /* 클릭아이템 초기값 설정 */
+  useEffect(() => {
+    setIsClicked(() => {
+      const initialState: Record<number, any> = {};
+      for (let i = 0; i <= paginationResult.showData.length; i++) {
+        initialState[i] = false;
+      }
+      return initialState;
+    });
+  }, [paginationResult.showData]);
+
+  /* 클릭시 카드의 전체 내용이 보이게 하는 함수*/
+  const showDetail = (index: number) => {
+    setIsClicked((prevIsHide) => ({
+      ...prevIsHide,
+      [index]: !prevIsHide[index],
+    }));
+  };
+
   return (
     /* 페이지네이션 Outlayer 레이아웃 */
     <PagenationHeader title={"리뷰"}>
       {paginationResult.showData.length ? (
         <>
-          {/* 페이지네이션 반복되는 카드 구역 */}
-          <ShowDataComponent
-            showData={paginationResult.showData}
-            renderCard={ReviewCard}
-          />
+          {/* 상태 변경을 처리하기위한 컨텍스트 */}
+          <PageNationContextProvider cardState={isClicked} func={showDetail}>
+            {/* 페이지네이션 반복되는 카드 구역 */}
+            <ShowDataComponent
+              showData={paginationResult.showData}
+              renderCard={ReviewCard}
+            />
+          </PageNationContextProvider>
 
           {/* 페이지네이션 숫자 네비게이터 구역 */}
           <PageNumNavComponent


### PR DESCRIPTION
페이지네이션에서 페이지번호가 키값이에 누락되었었음

페이지네이션 카드 부분에서 상태변화부분에서 반복문내에서 훅을 사용해서
예상하지못한 에러 발생, 컨텍스트를 사용 상태공유