### PR TITLE
[fix]: 장바구니 삭제된 데이터가 캐싱되어있는 에러 수정

### DIFF
--- a/services/buy/src/page/cart/CartPage.tsx
+++ b/services/buy/src/page/cart/CartPage.tsx
@@ -88,6 +88,7 @@ const CartPage = () => {
       //변경있으면 서버로 업데이트
       const newData = getSessionStorage("shoppingBag");
       await putInShoppingBagAPI(newData);
+      addSessionStorage("shoppingBag", []);
     };
 
     if (isChange) {


### PR DESCRIPTION
beforeunload이벤트로 서버로 장바구니 데이터 변경 요청 진행
이후 세션에 장바구니 정보를 초기화하지않아

장바구니페이지를 나갓다 다시들어오면 서버에게 전달할 데이터에
이전값이 다시 저장됨 -> 이벤트이후 초기화로 해결

  useEffect(() => {
    const handleBeforeUnload = async() => {
      //장바구니 데이터가 변경이 없으면
      if (!isChange) return;

      //변경있으면 서버로 업데이트
      const newData = getSessionStorage("shoppingBag");
      await putInShoppingBagAPI(newData);
      addSessionStorage("shoppingBag", []);
    };

    if (isChange) {
      console.log("이벤트 등록");
      window.addEventListener("beforeunload", handleBeforeUnload);
    }

    return () => {
      window.removeEventListener("beforeunload", handleBeforeUnload);
    };
  }, [isChange]);